### PR TITLE
Fix gunicorn request smuggling vulnerabilities

### DIFF
--- a/relay-server/requirements.txt
+++ b/relay-server/requirements.txt
@@ -1,5 +1,5 @@
 flask==3.0.0
 flask-sqlalchemy==3.1.1
 psycopg2-binary==2.9.9
-gunicorn==21.2.0
+gunicorn==22.0.0
 PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- Upgrade gunicorn from 21.2.0 to 22.0.0 in relay-server/requirements.txt
- Fixes Dependabot alert #1: Request smuggling leading to endpoint restriction bypass (CVSS 8.2)
- Fixes Dependabot alert #2: HTTP Request/Response Smuggling vulnerability (CVSS 7.5)

## Test plan
- [ ] Verify relay-server starts successfully with gunicorn 22.0.0
- [ ] Confirm Dependabot alerts are resolved after merge