### PR TITLE
Fix stack trace information exposure in health endpoint

### DIFF
--- a/relay-server/server.py
+++ b/relay-server/server.py
@@ -67,8 +67,8 @@ def health_check():
     try:
         db.session.execute(db.text("SELECT 1"))
         db_status = "connected"
-    except Exception as e:
-        db_status = f"error: {str(e)}"
+    except Exception:
+        db_status = "error"
 
     msg_count = QueuedMessage.query.filter_by(delivered=False).count()
     device_count = RegisteredDevice.query.count()


### PR DESCRIPTION
## Summary
- Remove exception details from `/api/v1/health` response to prevent information disclosure
- Addresses CodeQL alert #2: Information exposure through an exception (CWE-209, CWE-497)
- Database error status now returns `"error"` instead of leaking `str(e)`

## Test plan
- [ ] Verify health endpoint returns `"database": "error"` on DB failure without stack trace details
- [ ] Verify health endpoint still returns `"database": "connected"` when DB is healthy