### PR TITLE
feat: WebSocket real-time messaging and camera quality fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,16 @@
             android:name="org.torproject.jni.TorService"
             android:enabled="true"
             android:exported="false" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/meshcipher/MeshCipherApplication.kt
+++ b/app/src/main/java/com/meshcipher/MeshCipherApplication.kt
@@ -2,14 +2,24 @@ package com.meshcipher
 
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.*
 import com.meshcipher.data.cleanup.MessageCleanupManager
+import com.meshcipher.data.auth.RelayAuthManager
+import com.meshcipher.data.local.preferences.AppPreferences
+import com.meshcipher.data.relay.WebSocketManager
 import com.meshcipher.data.transport.P2PTransport
 import com.meshcipher.data.transport.WifiDirectTransport
 import com.meshcipher.data.worker.MessageCleanupWorker
 import com.meshcipher.data.worker.MessageSyncWorker
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -29,6 +39,17 @@ class MeshCipherApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var p2pTransport: P2PTransport
 
+    @Inject
+    lateinit var webSocketManager: WebSocketManager
+
+    @Inject
+    lateinit var appPreferences: AppPreferences
+
+    @Inject
+    lateinit var relayAuthManager: RelayAuthManager
+
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
     override fun onCreate() {
         super.onCreate()
 
@@ -43,6 +64,7 @@ class MeshCipherApplication : Application(), Configuration.Provider {
         setupAppLifecycleObserver()
         initializeWifiDirect()
         initializeP2PTransport()
+        setupWebSocket()
     }
 
     private fun initializeWifiDirect() {
@@ -103,6 +125,38 @@ class MeshCipherApplication : Application(), Configuration.Provider {
         )
 
         Timber.d("Message cleanup worker scheduled")
+    }
+
+    private fun setupWebSocket() {
+        // Pre-warm auth token immediately so WebSocket connect is fast
+        appScope.launch(Dispatchers.IO) {
+            val userId = appPreferences.userId.firstOrNull()
+            if (!userId.isNullOrBlank()) {
+                Timber.d("Pre-warming auth token")
+                relayAuthManager.ensureAuthenticated()
+                // Connect WebSocket right away (app starts in foreground)
+                Timber.d("Auth ready, connecting WebSocket")
+                webSocketManager.connect(userId)
+            }
+        }
+
+        // Reconnect/disconnect on foreground/background transitions
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                appScope.launch {
+                    val userId = appPreferences.userId.firstOrNull()
+                    if (!userId.isNullOrBlank()) {
+                        Timber.d("App foregrounded, connecting WebSocket")
+                        webSocketManager.connect(userId)
+                    }
+                }
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                Timber.d("App backgrounded, disconnecting WebSocket")
+                webSocketManager.disconnect()
+            }
+        })
     }
 
     private fun setupAppLifecycleObserver() {

--- a/app/src/main/java/com/meshcipher/data/media/MediaProcessor.kt
+++ b/app/src/main/java/com/meshcipher/data/media/MediaProcessor.kt
@@ -107,8 +107,8 @@ class MediaProcessor @Inject constructor() {
     }
 
     companion object {
-        private const val MAX_IMAGE_DIMENSION = 1280
-        private const val JPEG_QUALITY = 80
+        private const val MAX_IMAGE_DIMENSION = 2048
+        private const val JPEG_QUALITY = 90
         private const val MAX_VIDEO_SIZE = 15L * 1024 * 1024 // 15MB
     }
 }

--- a/app/src/main/java/com/meshcipher/data/relay/WebSocketManager.kt
+++ b/app/src/main/java/com/meshcipher/data/relay/WebSocketManager.kt
@@ -1,0 +1,215 @@
+package com.meshcipher.data.relay
+
+import com.meshcipher.data.auth.RelayAuthManager
+import com.meshcipher.data.local.preferences.AppPreferences
+import com.meshcipher.data.remote.dto.QueuedMessage
+import com.meshcipher.domain.usecase.ReceiveMessageUseCase
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import okhttp3.*
+import org.json.JSONObject
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class WebSocketState {
+    DISCONNECTED,
+    CONNECTING,
+    AUTHENTICATING,
+    CONNECTED
+}
+
+@Singleton
+class WebSocketManager @Inject constructor(
+    private val relayAuthManager: RelayAuthManager,
+    private val appPreferences: AppPreferences,
+    private val receiveMessageUseCase: ReceiveMessageUseCase
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _connectionState = MutableStateFlow(WebSocketState.DISCONNECTED)
+    val connectionState: StateFlow<WebSocketState> = _connectionState.asStateFlow()
+
+    private var webSocket: WebSocket? = null
+    private var reconnectJob: Job? = null
+    private var reconnectAttempt = 0
+    private var userId: String? = null
+    private var intentionalClose = false
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS) // No read timeout for WebSocket
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .pingInterval(25, TimeUnit.SECONDS) // OkHttp handles ping/pong
+        .build()
+
+    fun connect(userIdValue: String) {
+        if (_connectionState.value == WebSocketState.CONNECTING ||
+            _connectionState.value == WebSocketState.AUTHENTICATING ||
+            _connectionState.value == WebSocketState.CONNECTED
+        ) {
+            return
+        }
+
+        userId = userIdValue
+        intentionalClose = false
+        reconnectAttempt = 0
+        doConnect()
+    }
+
+    fun disconnect() {
+        intentionalClose = true
+        reconnectJob?.cancel()
+        reconnectJob = null
+        webSocket?.close(1000, "Client disconnect")
+        webSocket = null
+        _connectionState.value = WebSocketState.DISCONNECTED
+    }
+
+    private fun doConnect() {
+        _connectionState.value = WebSocketState.CONNECTING
+
+        scope.launch {
+            try {
+                val token = relayAuthManager.ensureAuthenticated()
+                if (token == null) {
+                    Timber.w("Cannot connect WebSocket: no auth token")
+                    _connectionState.value = WebSocketState.DISCONNECTED
+                    scheduleReconnect()
+                    return@launch
+                }
+
+                val baseUrl = appPreferences.relayServerUrl.first()
+                val wsUrl = baseUrl
+                    .trimEnd('/')
+                    .replace("https://", "wss://")
+                    .replace("http://", "ws://") + "/api/v1/relay/ws"
+
+                val request = Request.Builder()
+                    .url(wsUrl)
+                    .build()
+
+                webSocket = client.newWebSocket(request, createListener(token))
+            } catch (e: Exception) {
+                Timber.e(e, "WebSocket connect failed")
+                _connectionState.value = WebSocketState.DISCONNECTED
+                scheduleReconnect()
+            }
+        }
+    }
+
+    private fun createListener(token: String): WebSocketListener {
+        return object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                Timber.d("WebSocket opened, sending auth")
+                _connectionState.value = WebSocketState.AUTHENTICATING
+
+                val authMsg = JSONObject().apply {
+                    put("type", "auth")
+                    put("token", token)
+                }
+                webSocket.send(authMsg.toString())
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                try {
+                    val json = JSONObject(text)
+                    when (json.optString("type")) {
+                        "authenticated" -> {
+                            Timber.d("WebSocket authenticated")
+                            _connectionState.value = WebSocketState.CONNECTED
+                            reconnectAttempt = 0
+
+                            // Fetch any messages queued while disconnected
+                            scope.launch {
+                                try {
+                                    val uid = userId ?: return@launch
+                                    receiveMessageUseCase(uid)
+                                } catch (e: Exception) {
+                                    Timber.w(e, "Initial message fetch failed")
+                                }
+                            }
+                        }
+                        "new_message" -> {
+                            Timber.d("WebSocket received push message")
+                            val msgJson = json.optJSONObject("message")
+                            if (msgJson != null) {
+                                val queued = QueuedMessage(
+                                    id = msgJson.getString("id"),
+                                    senderId = msgJson.getString("sender_id"),
+                                    recipientId = msgJson.getString("recipient_id"),
+                                    encryptedContent = msgJson.getString("encrypted_content"),
+                                    contentType = msgJson.optInt("content_type", 0),
+                                    queuedAt = msgJson.optString("queued_at", "")
+                                )
+                                scope.launch {
+                                    try {
+                                        val uid = userId ?: return@launch
+                                        receiveMessageUseCase.processAndAcknowledge(queued, uid)
+                                    } catch (e: Exception) {
+                                        Timber.w(e, "Direct message processing failed, falling back to poll")
+                                        try {
+                                            val uid = userId ?: return@launch
+                                            receiveMessageUseCase(uid)
+                                        } catch (_: Exception) {}
+                                    }
+                                }
+                            }
+                        }
+                        "error" -> {
+                            val msg = json.optString("message", "Unknown error")
+                            Timber.e("WebSocket error: %s", msg)
+                            if (msg == "Token expired" || msg == "Invalid token") {
+                                webSocket.close(1000, "Re-authenticating")
+                            }
+                        }
+                        "pong" -> { /* Expected response to our ping */ }
+                    }
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to parse WebSocket message")
+                }
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                Timber.w(t, "WebSocket failure (code: %s)", response?.code)
+                _connectionState.value = WebSocketState.DISCONNECTED
+                this@WebSocketManager.webSocket = null
+                if (!intentionalClose) {
+                    scheduleReconnect()
+                }
+            }
+
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                Timber.d("WebSocket closing: %d %s", code, reason)
+                webSocket.close(code, reason)
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                Timber.d("WebSocket closed: %d %s", code, reason)
+                _connectionState.value = WebSocketState.DISCONNECTED
+                this@WebSocketManager.webSocket = null
+                if (!intentionalClose) {
+                    scheduleReconnect()
+                }
+            }
+        }
+    }
+
+    private fun scheduleReconnect() {
+        if (intentionalClose) return
+
+        reconnectJob?.cancel()
+        reconnectJob = scope.launch {
+            val delayMs = minOf(
+                1000L * (1L shl minOf(reconnectAttempt, 5)),
+                30_000L
+            )
+            reconnectAttempt++
+            Timber.d("WebSocket reconnecting in %dms (attempt %d)", delayMs, reconnectAttempt)
+            delay(delayMs)
+            doConnect()
+        }
+    }
+}

--- a/app/src/main/java/com/meshcipher/domain/usecase/ReceiveMessageUseCase.kt
+++ b/app/src/main/java/com/meshcipher/domain/usecase/ReceiveMessageUseCase.kt
@@ -64,6 +64,21 @@ class ReceiveMessageUseCase @Inject constructor(
         return Result.success(processedCount)
     }
 
+    /**
+     * Process a single message received via WebSocket push and acknowledge it.
+     * Skips the HTTP fetch since the message data is already available.
+     */
+    suspend fun processAndAcknowledge(queued: QueuedMessage, localDeviceId: String): Result<Unit> {
+        return try {
+            processQueuedMessage(queued)
+            transportManager.getActiveTransport().acknowledgeMessages(localDeviceId, listOf(queued.id))
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to process pushed message: %s", queued.id)
+            Result.failure(e)
+        }
+    }
+
     private suspend fun processQueuedMessage(queued: QueuedMessage) {
         when (queued.contentType) {
             1 -> processMediaMessage(queued)

--- a/app/src/main/java/com/meshcipher/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/meshcipher/presentation/chat/ChatScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -68,15 +69,15 @@ fun ChatScreen(
         uri?.let { viewModel.sendMediaMessage(context, it, MediaType.VIDEO) }
     }
 
+    var cameraImageUri by remember { mutableStateOf<Uri?>(null) }
+
     val cameraLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.TakePicturePreview()
-    ) { bitmap ->
-        if (bitmap != null) {
-            val file = File(context.cacheDir, "camera_${System.currentTimeMillis()}.jpg")
-            file.outputStream().use { out ->
-                bitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 90, out)
+        ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success) {
+            cameraImageUri?.let { uri ->
+                viewModel.sendMediaMessage(context, uri, MediaType.IMAGE)
             }
-            viewModel.sendMediaMessage(context, Uri.fromFile(file), MediaType.IMAGE)
         }
     }
 
@@ -223,7 +224,10 @@ fun ChatScreen(
             onDismiss = { viewModel.dismissMediaPicker() },
             onCameraClick = {
                 viewModel.dismissMediaPicker()
-                cameraLauncher.launch(null)
+                val photoFile = File(context.cacheDir, "camera_${System.currentTimeMillis()}.jpg")
+                val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", photoFile)
+                cameraImageUri = uri
+                cameraLauncher.launch(uri)
             },
             onGalleryClick = {
                 viewModel.dismissMediaPicker()

--- a/app/src/main/java/com/meshcipher/presentation/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/meshcipher/presentation/chat/ChatViewModel.kt
@@ -16,6 +16,8 @@ import com.meshcipher.data.media.VoicePlayer
 import com.meshcipher.data.media.VoiceRecorder
 import com.meshcipher.data.identity.IdentityManager
 import com.meshcipher.data.local.preferences.AppPreferences
+import com.meshcipher.data.relay.WebSocketManager
+import com.meshcipher.data.relay.WebSocketState
 import com.meshcipher.domain.model.Contact
 import com.meshcipher.domain.model.Conversation
 import com.meshcipher.domain.model.MediaAttachment
@@ -56,6 +58,7 @@ class ChatViewModel @Inject constructor(
     private val receiveMessageUseCase: ReceiveMessageUseCase,
     private val identityManager: IdentityManager,
     private val appPreferences: AppPreferences,
+    private val webSocketManager: WebSocketManager,
     private val mediaProcessor: MediaProcessor,
     private val mediaEncryptor: MediaEncryptor,
     private val mediaFileManager: MediaFileManager,
@@ -113,18 +116,32 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch {
             conversationRepository.markConversationAsRead(conversationId)
         }
-        // Poll for new messages every 5 seconds while chat is open
+        // Auto-mark as read when new messages arrive via WebSocket
+        viewModelScope.launch {
+            messages.collect {
+                conversationRepository.markConversationAsRead(conversationId)
+            }
+        }
+        // Fallback polling when WebSocket is disconnected
         viewModelScope.launch {
             val userId = appPreferences.userId.firstOrNull()
             if (!userId.isNullOrBlank()) {
+                // Immediate poll on chat open for instant first message
+                try {
+                    receiveMessageUseCase(userId)
+                    conversationRepository.markConversationAsRead(conversationId)
+                } catch (_: Exception) {}
+                // Then poll every 3s only when WS is down
                 while (true) {
-                    try {
-                        receiveMessageUseCase(userId)
-                        conversationRepository.markConversationAsRead(conversationId)
-                    } catch (e: Exception) {
-                        Timber.w(e, "Chat poll failed")
+                    delay(3_000)
+                    if (webSocketManager.connectionState.value != WebSocketState.CONNECTED) {
+                        try {
+                            receiveMessageUseCase(userId)
+                            conversationRepository.markConversationAsRead(conversationId)
+                        } catch (e: Exception) {
+                            Timber.w(e, "Chat poll failed")
+                        }
                     }
-                    delay(5_000)
                 }
             }
         }

--- a/app/src/main/java/com/meshcipher/presentation/conversations/ConversationsViewModel.kt
+++ b/app/src/main/java/com/meshcipher/presentation/conversations/ConversationsViewModel.kt
@@ -3,6 +3,8 @@ package com.meshcipher.presentation.conversations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.meshcipher.data.local.preferences.AppPreferences
+import com.meshcipher.data.relay.WebSocketManager
+import com.meshcipher.data.relay.WebSocketState
 import com.meshcipher.domain.model.ConnectionMode
 import com.meshcipher.domain.model.Conversation
 import com.meshcipher.domain.usecase.GetConversationsUseCase
@@ -22,7 +24,8 @@ import javax.inject.Inject
 class ConversationsViewModel @Inject constructor(
     getConversationsUseCase: GetConversationsUseCase,
     private val receiveMessageUseCase: ReceiveMessageUseCase,
-    private val appPreferences: AppPreferences
+    private val appPreferences: AppPreferences,
+    private val webSocketManager: WebSocketManager
 ) : ViewModel() {
 
     val conversations: StateFlow<List<Conversation>> = getConversationsUseCase()
@@ -46,13 +49,16 @@ class ConversationsViewModel @Inject constructor(
             initialValue = ConnectionMode.DIRECT
         )
 
+    val wsState: StateFlow<WebSocketState> = webSocketManager.connectionState
+
     init {
-        // Poll for new messages immediately when conversations screen opens,
-        // then every 10 seconds while it's visible
+        // Fallback polling: only polls when WebSocket is disconnected
         viewModelScope.launch {
             while (true) {
-                pollMessages()
-                delay(10_000)
+                if (webSocketManager.connectionState.value != WebSocketState.CONNECTED) {
+                    pollMessages()
+                }
+                delay(15_000)
             }
         }
     }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="cache" path="." />
+</paths>

--- a/app/src/test/java/com/meshcipher/presentation/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/java/com/meshcipher/presentation/conversations/ConversationsViewModelTest.kt
@@ -1,14 +1,20 @@
 package com.meshcipher.presentation.conversations
 
-import app.cash.turbine.test
 import com.meshcipher.data.local.preferences.AppPreferences
+import com.meshcipher.data.relay.WebSocketManager
+import com.meshcipher.data.relay.WebSocketState
 import com.meshcipher.domain.model.Conversation
 import com.meshcipher.domain.usecase.GetConversationsUseCase
+import com.meshcipher.domain.usecase.ReceiveMessageUseCase
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.*
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -19,17 +25,25 @@ import org.junit.Test
 class ConversationsViewModelTest {
 
     private lateinit var getConversationsUseCase: GetConversationsUseCase
+    private lateinit var receiveMessageUseCase: ReceiveMessageUseCase
     private lateinit var appPreferences: AppPreferences
+    private lateinit var webSocketManager: WebSocketManager
     private lateinit var viewModel: ConversationsViewModel
 
-    private val testDispatcher = StandardTestDispatcher()
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = StandardTestDispatcher(testScheduler)
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         getConversationsUseCase = mockk()
+        receiveMessageUseCase = mockk()
         appPreferences = mockk()
+        webSocketManager = mockk()
         every { appPreferences.connectionMode } returns flowOf("DIRECT")
+        every { appPreferences.userId } returns flowOf(null)
+        every { webSocketManager.connectionState } returns MutableStateFlow(WebSocketState.DISCONNECTED)
+        coEvery { receiveMessageUseCase(any()) } returns Result.success(0)
     }
 
     @After
@@ -38,7 +52,7 @@ class ConversationsViewModelTest {
     }
 
     @Test
-    fun `conversations flow emits data from use case`() = runTest {
+    fun `conversations flow emits data from use case`() {
         val conversations = listOf(
             Conversation(
                 id = "conv-1",
@@ -53,12 +67,20 @@ class ConversationsViewModelTest {
 
         every { getConversationsUseCase() } returns flowOf(conversations)
 
-        viewModel = ConversationsViewModel(getConversationsUseCase, appPreferences)
+        viewModel = ConversationsViewModel(getConversationsUseCase, receiveMessageUseCase, appPreferences, webSocketManager)
 
-        viewModel.conversations.test {
-            // Initial value is emptyList from stateIn
-            skipItems(1)
-            assertEquals(conversations, awaitItem())
+        // Start a subscriber to activate WhileSubscribed stateIn
+        var result: List<Conversation> = emptyList()
+        val scope = TestScope(testDispatcher)
+        val job = scope.launch {
+            viewModel.conversations.collect { result = it }
         }
+
+        // Advance to let the flow emit
+        testScheduler.advanceTimeBy(1000)
+        testScheduler.runCurrent()
+
+        assertEquals(conversations, result)
+        job.cancel()
     }
 }

--- a/relay-server/requirements.txt
+++ b/relay-server/requirements.txt
@@ -5,3 +5,4 @@ cryptography==46.0.4
 psycopg2-binary==2.9.9
 gunicorn==25.0.3
 PyJWT==2.11.0
+flask-sock==0.7.0

--- a/relay-server/server.py
+++ b/relay-server/server.py
@@ -12,10 +12,14 @@ from functools import wraps
 import jwt as pyjwt
 from cryptography.hazmat.primitives.asymmetric import ec, utils
 from cryptography.hazmat.primitives import hashes, serialization
+import json
+import threading
+
 from flask import Flask, jsonify, request, g, session, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_sock import Sock
 
 app = Flask(__name__)
 
@@ -67,6 +71,16 @@ limiter = Limiter(
     default_limits=["200 per minute"],
     storage_uri="memory://",
 )
+
+sock = Sock(app)
+
+# ---------------------------------------------------------------------------
+# WebSocket Active Connections
+# ---------------------------------------------------------------------------
+
+# Maps user_id -> WebSocket object for connected clients
+ws_connections = {}
+ws_lock = threading.Lock()
 
 # ---------------------------------------------------------------------------
 # Models
@@ -338,6 +352,95 @@ def verify_challenge():
 
 
 # ---------------------------------------------------------------------------
+# WebSocket Endpoint
+# ---------------------------------------------------------------------------
+
+
+def ws_push_message(recipient_id, message_data):
+    """Push a message to a connected WebSocket client. Returns True if delivered."""
+    with ws_lock:
+        ws = ws_connections.get(recipient_id)
+    if ws is None:
+        return False
+    try:
+        ws.send(json.dumps({"type": "new_message", "message": message_data}))
+        return True
+    except Exception:
+        # Connection is dead, clean up
+        with ws_lock:
+            ws_connections.pop(recipient_id, None)
+        return False
+
+
+@sock.route("/api/v1/relay/ws")
+def websocket_endpoint(ws):
+    """Raw WebSocket endpoint. Client must send auth message first."""
+    user_id = None
+    try:
+        # Wait for auth message (timeout handled by OkHttp ping/pong)
+        auth_raw = ws.receive(timeout=30)
+        if auth_raw is None:
+            return
+
+        try:
+            auth_msg = json.loads(auth_raw)
+        except (json.JSONDecodeError, TypeError):
+            ws.send(json.dumps({"type": "error", "message": "Invalid JSON"}))
+            return
+
+        if auth_msg.get("type") != "auth" or not auth_msg.get("token"):
+            ws.send(json.dumps({"type": "error", "message": "Expected auth message"}))
+            return
+
+        # Verify JWT token
+        token = auth_msg["token"]
+        try:
+            payload = pyjwt.decode(
+                token, app.config["SECRET_KEY"], algorithms=["HS256"]
+            )
+            user_id = payload["user_id"]
+        except pyjwt.ExpiredSignatureError:
+            ws.send(json.dumps({"type": "error", "message": "Token expired"}))
+            return
+        except pyjwt.InvalidTokenError:
+            ws.send(json.dumps({"type": "error", "message": "Invalid token"}))
+            return
+
+        # Register this connection
+        with ws_lock:
+            ws_connections[user_id] = ws
+
+        ws.send(json.dumps({"type": "authenticated", "user_id": user_id}))
+
+        # Update last_seen
+        with app.app_context():
+            device = RegisteredDevice.query.filter_by(user_id=user_id).first()
+            if device:
+                device.last_seen = datetime.now(timezone.utc)
+                db.session.commit()
+
+        # Keep connection alive - receive pings/messages
+        while True:
+            msg = ws.receive(timeout=300)
+            if msg is None:
+                break
+            try:
+                data = json.loads(msg)
+                if data.get("type") == "ping":
+                    ws.send(json.dumps({"type": "pong"}))
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    except Exception:
+        pass
+    finally:
+        if user_id:
+            with ws_lock:
+                if ws_connections.get(user_id) is ws:
+                    ws_connections.pop(user_id, None)
+
+
+# ---------------------------------------------------------------------------
 # Relay Endpoints (require authentication)
 # ---------------------------------------------------------------------------
 
@@ -381,10 +484,20 @@ def relay_message():
     db.session.add(message)
     db.session.commit()
 
+    # Try to push via WebSocket if recipient is connected
+    pushed = ws_push_message(recipient_id, {
+        "id": message.id,
+        "sender_id": sender_id,
+        "recipient_id": recipient_id,
+        "encrypted_content": encrypted_content,
+        "content_type": content_type,
+        "queued_at": message.queued_at.isoformat(),
+    })
+
     return (
         jsonify(
             {
-                "status": "queued",
+                "status": "pushed" if pushed else "queued",
                 "message_id": message.id,
                 "queued_at": message.queued_at.isoformat(),
             }


### PR DESCRIPTION
## Summary
- Add WebSocket endpoint to relay server (flask-sock + gevent) for instant message push
- Add WebSocketManager on Android with OkHttp, auto-reconnect, and pre-warmed auth
- Direct message processing from WS payload eliminates HTTP round-trip latency
- Fix camera capturing low-res thumbnails (TakePicturePreview -> TakePicture)
- Bump image quality settings (2048px max, 90% JPEG)

## Changes
- **relay-server/server.py** - WebSocket endpoint `/api/v1/relay/ws`, JWT auth, push on relay
- **relay-server/requirements.txt** - Add flask-sock
- **WebSocketManager.kt** - New singleton, OkHttp WS client, exponential backoff reconnect
- **MeshCipherApplication.kt** - Pre-warm auth, connect WS on foreground/disconnect on background
- **ReceiveMessageUseCase.kt** - Add processAndAcknowledge() for direct WS message processing
- **ChatViewModel.kt** - 3s fallback poll only when WS disconnected, immediate poll on open
- **ConversationsViewModel.kt** - 15s fallback poll only when WS disconnected
- **ChatScreen.kt** - TakePicture with FileProvider for full-res camera capture
- **MediaProcessor.kt** - MAX_IMAGE_DIMENSION 1280->2048, JPEG_QUALITY 80->90
- **AndroidManifest.xml** - FileProvider for camera URI
- **file_paths.xml** - Cache directory path config

## Test plan
- [ ] Send text message - should arrive in under 1 second
- [ ] Kill app, send message, reopen - message appears via fallback poll
- [ ] Toggle airplane mode - WS reconnects automatically
- [ ] Take photo via camera - full resolution, not thumbnail
- [ ] Send gallery photo - quality preserved