### PR TITLE
ci: Add CodeQL Advanced Setup for Android Kotlin analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Configure Android SDK path
+        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+
+      - name: Grant Gradle execute permission
+        run: chmod +x gradlew
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.28.14
+        with:
+          languages: java-kotlin
+          queries: security-and-quality
+
+      - name: Build (CodeQL trace)
+        run: ./gradlew :app:compileDebugKotlin --no-daemon
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.28.14
+        with:
+          category: language:java-kotlin


### PR DESCRIPTION
## Problem

GitHub's CodeQL Default Setup auto-detected Kotlin code and attempted to scan it, but it has no knowledge of the Android build environment. It fails every time because:

- No Android SDK path configured (`local.properties` missing)
- Default Setup doesn't run `./gradlew` with Android tooling
- Result: "CodeQL exited with errors" + ghost `language:java-kotlin` entry in Security tab with zero successful scans

## Fix

Custom CodeQL workflow (Advanced Setup) that properly builds the project before analysis:

1. Sets up JDK 17 (temurin) with Gradle cache
2. Writes `local.properties` pointing to `$ANDROID_SDK_ROOT` (pre-installed on `ubuntu-latest`)
3. Runs `./gradlew :app:compileDebugKotlin --no-daemon` as the CodeQL build trace
4. Uploads results under `language:java-kotlin` category

## After merge

Once this runs successfully, the ghost Default Setup entry for `java-kotlin` in the Security tab will be replaced by this working scan. No other changes needed — Default Setup for `actions` and `python` continues to run separately.