### PR TITLE
build(deps): bump cryptography, gunicorn and codeql-action SHA

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.28.14
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v3.28.14
         if: always()
         with:
           sarif_file: trivy-results.sarif
@@ -74,6 +74,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard results
-        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.28.14
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v3.28.14
         with:
           sarif_file: scorecard-results.sarif

--- a/relay-server/requirements.txt
+++ b/relay-server/requirements.txt
@@ -1,8 +1,8 @@
 flask==3.1.3
 flask-sqlalchemy==3.1.1
 flask-limiter==4.1.1
-cryptography==46.0.4
+cryptography==46.0.6
 psycopg2-binary==2.9.11
-gunicorn==25.0.3
+gunicorn==25.3.0
 PyJWT==2.12.1
 flask-sock==0.7.0


### PR DESCRIPTION
Consolidates three Dependabot PRs that conflicted with each other when targeting main:

- cryptography 46.0.4 → 46.0.6 (security fix, closes #73)
- gunicorn 25.0.3 → 25.3.0 (closes #74)
- github/codeql-action/upload-sarif SHA pin update (closes #69)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration
  * Updated package dependencies (`cryptography` and `gunicorn`) to latest stable versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->